### PR TITLE
Remove the most accurate patch level

### DIFF
--- a/targets/debian-wheezy.yaml
+++ b/targets/debian-wheezy.yaml
@@ -2,5 +2,5 @@ name: Debian Wheezy
 eol: 2018-05-31
 info: https://wiki.debian.org/DebianReleases
 rules:
-  - SSH-2.0-OpenSSH_6.0p1 Debian-4+deb7u2
+  - SSH-2.0-OpenSSH_6.0p1 Debian-4+deb7
   - Apache/2.2.22 (Debian)


### PR DESCRIPTION
It seems that the uX part in Debian-4+deb7uX varies inside the distro. We should consider removing all uX parts from elsewhere too. Fixing now the one I noticed in practice.