### PR TITLE
Win2012R2 ESU has ended

### DIFF
--- a/targets/windows-server-2012-r2.yaml
+++ b/targets/windows-server-2012-r2.yaml
@@ -1,4 +1,4 @@
-name: Windows Server 2012 R2 (unless ESU) or Windows 8.1
+name: Windows Server 2012 R2 or Windows 8.1
 eol: 2023-10-10
 info: https://docs.microsoft.com/en-us/lifecycle/products/internet-information-services-iis
 rules:


### PR DESCRIPTION
https://learn.microsoft.com/en-us/windows-server/get-started/extended-security-updates-overview

*Extended support for Windows Server 2012 and Windows Server 2012 R2 will be ending on October 10, 2023.*