### PR TITLE
Update rocky-linux-8-4.yaml

### DIFF
--- a/targets/rocky-linux-8-4.yaml
+++ b/targets/rocky-linux-8-4.yaml
@@ -2,4 +2,5 @@ name: Rocky Linux 8.3 or 8.4
 eol: 2021-11-15
 info: https://wiki.rockylinux.org/rocky/version/
 rules:
-  - Apache/2.4.37 (rocky) OpenSSL/1.1.1g
+  - Apache/2.4.37 (rocky)
+  - Apache/2.4.37 (Rocky Linux)


### PR DESCRIPTION
- Added a shorter version of a server string I just saw ("Server: Apache/2.4.37 (Rocky Linux) OpenSSL/1.1.1k PHP/7.3.20")
- Loosened up the previous rule a bit as it seems that OpenSSL versions could change while the Apache version stays the same?
- Proposing we remove the openssl versions from rocky-linuxes alltogether?


