### PR TITLE
Revert "Delete future EOL target Ubuntu Focal"

### DIFF
--- a/targets/ubuntu-focal.yaml
+++ b/targets/ubuntu-focal.yaml
@@ -1,0 +1,5 @@
+name: Ubuntu Focal (unless ESM)
+eol: 2025-05-31
+info: https://wiki.ubuntu.com/Releases
+rules:
+  - Apache/2.4.41 (Ubuntu)


### PR DESCRIPTION
This pull request adds back the Ubuntu Focal target by reverting the commit 61d59d96aa52953eb6b3ac46e1682f4820952ce1 included in #17.

We now support EOL dates pointing into the future, so it's okay that the Ubuntu Focal target's EOL date is 2025-05-31.